### PR TITLE
Bulk update

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ Updates incoming data by building a `criteria` from an array of `keys` and the i
 Example
 
 ```js
-// The following updates incoming persons using the personId as a criteria
+// The following updates incoming persons using the personId as a criteria (100 records at a time)
 
 etl.file('test.csv')
   .pipe(etl.csv())
+  .pipe(etl.collect(100))
   .pipe(mongo.update(collection,['personId']));
 
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,12 @@
 machine:
   services:
     - elasticsearch
+dependencies:
+  # Setup mongodb 2.6.6 on the test instance; Circle defaults to v2.4.x which is missing some features we utilize.
+  cache_directories:
+    - mongodb-linux-x86_64-2.6.6
+  pre:
+    - if [[ ! -d mongodb-linux-x86_64-2.6.6 ]]; then wget http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.6.6.tgz && tar xvzf mongodb-linux-x86_64-2.6.6.tgz; fi
+    - sudo /etc/init.d/mongodb stop
+    - sudo cp mongodb-linux-x86_64-2.6.6/bin/* /usr/bin
+    - sudo /etc/init.d/mongodb start

--- a/lib/mongo/index.js
+++ b/lib/mongo/index.js
@@ -1,4 +1,4 @@
 module.exports = {
   insert : require('./insert'),
-  update : require('./update')
+  update : require('./update'),
 };

--- a/lib/mongo/update.js
+++ b/lib/mongo/update.js
@@ -13,25 +13,43 @@ function Update(_c,collection,keys,options) {
     _c = undefined;
   }
 
+  if (keys === undefined)
+    throw new Error('Missing Keys');
+
   Streamz.call(this, _c, null, options);
   this.collection = Promise.resolve(collection);
   this.options = options || {};
-  this.keys = keys;
+  this.keys = [].concat(keys);
 }
 
 util.inherits(Update,Streamz);
 
 Update.prototype._fn = function(d,cb) {
   var self = this;
-  var criteria = this.keys.reduce(function(p,key) {
-    p[key] = d[key];
-    return p;
-  },{});
 
   this.collection
     .then(function(collection) {
-      collection.update(criteria,{$set:d},self.options,function(err,d) {
-        cb(err,self.options.pushResult && d.result);
+      var bulk = collection.initializeUnorderedBulkOp();
+
+      [].concat(d || []).forEach(function(d) {
+        var criteria = self.keys.reduce(function(p,key) {
+          if (d[key] === undefined)
+            throw new Error('Key not found in data');
+          p[key] = d[key];
+          delete d[key];
+          return p;
+        },{});
+
+        var op = bulk.find(criteria);
+
+        if (self.options.upsert)
+          op = op.upsert();
+
+        op.updateOne({$set:d});
+      });
+
+      bulk.execute(self.options,function(err,d) {
+        cb(err,self.options.pushResult && d);
       });
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",

--- a/test/lib/mongo.js
+++ b/test/lib/mongo.js
@@ -7,7 +7,7 @@ Promise.promisifyAll(mongo);
 Promise.promisifyAll(mongo.MongoClient);
 
 module.exports = {
-  db : mongo.connectAsync('mongodb://localhost:27017'),
+  db : mongo.connectAsync('mongodb://localhost:27017/etl_tests'),
 
   getCollection : function(name) {
     var self = this,collection;

--- a/test/mongo-update-test.js
+++ b/test/mongo-update-test.js
@@ -1,131 +1,169 @@
 var etl = require('../index'),
     inspect = require('./lib/inspect'),
+    Promise = require('bluebird'),
     assert = require('assert'),
     data = require('./data'),
     mongo = require('./lib/mongo');
 
 describe('mongo update',function() {
-  describe('on an empty collection',function() {
-    it('should fail to update',function() {
-      return mongo.getCollection('update-empty')
-        .then(function(collection) {
-          var update = etl.mongo.update(collection,['name'],{pushResult:true});
 
-          data.stream()
-            .pipe(update);
+  describe('single record',function() {
+    var collection = mongo.getCollection('update-empty');
 
-          return inspect(update);
-        })
+    it('missing keys fails',function() {
+      return Promise.try(function() {
+          return etl.mongo.update(collection);
+         })
+        .then(function() {
+          throw 'Should result in an error';
+        },Object);
+    });
+
+    it('upserts into mongo',function() {
+      var insert = etl.mongo.update(collection,['__line'],{upsert: true, pushResult:true});
+      var data = etl.map();
+      data.end({name:'single record',__line:999});
+
+      data.pipe(insert);
+
+      return inspect(insert)
         .then(function(d) {
-          d.forEach(function(d) {
-            if (d.nModified !== undefined)
-              assert.deepEqual(d,{ok:1,nModified:0,n:0});
-            else
-              assert.deepEqual(d,{ok:1,n:0,upserted:[]});
-          });
+          d = d[0];
+          assert.equal(d.nUpserted,1);   
         });
     });
-  });
 
-  it('pushResults == false and collection as promise',function() {
-    return mongo.getCollection('update-empty')
-      .then(function(collection) {
-        var update = etl.mongo.update(collection,['name']);
+    it('updates into mongo',function() {
+      var insert = etl.mongo.update(collection,['__line'],{pushResult:true});
+      var data = etl.map();
+      data.end({name:'updated single record',__line:999});
 
-        data.stream()
-          .pipe(update);
-
-        return inspect(update);
-      })
-      .then(function(d) {
-        assert.deepEqual(d,[]);
-      });
-  });
-          
-
-  describe('on a populated collection',function() {
-    it('should update matches',function() {
-      return mongo.getCollection('update-populated',true)
-        .then(function(collection) {
-          return collection.insertAsync(data.copy())
-            .then(function() {
-              var update = etl.mongo.update(collection,['name'],{pushResult:true});
-
-              data.stream()
-                .pipe(etl.map(function(d) {
-                  if (d.name == 'Nathaniel Olson')
-                    d.name = 'Not Found';
-                  d.newfield='newfield';
-                  return d;
-                }))
-                .pipe(update);
-
-              return inspect(update);
-            });
-        })
+      data.pipe(insert);
+      return inspect(insert)
         .then(function(d) {
-          // The first one wasn't found
-          if (d[0].nModified !== undefined)
-            assert.deepEqual(d[0],{ok:1,nModified:0,n:0});
+          d = d[0];
+          if (d.nModified === null)
+              console.log('WARNING - Mongo 2.6 or higher needed for nModfied');
           else
-            assert.deepEqual(d[0],{ok:1,n:0,upserted:[]});
-
-
-          // The others are modified
-          d.slice(1).forEach(function(d) {
-            if (d.nModified !== undefined)
-              assert.deepEqual(d,{ok:1,nModified:1,n:1});
-            else
-              assert.deepEqual(d,{ok:1,n:1});
-          });  
-        });
-    });
-
-
-    it('results are saved',function() {
-      return mongo.getCollection('update-populated',true)
-        .then(function(collection) {
-          return collection.find({},{_id:false}).toArrayAsync();
-        })
-        .then(function(d) {
-          var expected = data.copy().map(function(d,i) {
-            if (i) d.newfield = 'newfield';
-            return d;
-          });
-
-          assert.deepEqual(d,expected);            
+            assert.equal(d.nModified,1);
         });
     });
   });
 
-  describe('using upsert',function() {
-    it('should populate',function() {
-      return mongo.getCollection('upsert')
-        .then(function(collection) {
-          var upsert = etl.mongo.update(collection,['name'],{pushResult:true,upsert:true});
+  describe('bulk',function() {
+    describe('on an empty collection',function() {
+      it('should fail to update',function() {
+        return mongo.getCollection('update-empty')
+          .then(function(collection) {
+            var update = etl.mongo.update(collection,['name'],{pushResult:true});
 
-          data.stream().pipe(upsert);
+            data.stream()
+              .pipe(etl.collect(100))
+              .pipe(update);
 
-          return inspect(upsert);
-        })
-        .then(function(d) {
-          d.forEach(function(d) {
-            if (d.nModified !== undefined)
-              assert.deepEqual(d,{ok:1,nModified:0,n:1,upserted:d.upserted});
-            else
-              assert.deepEqual(d,{ok:1,n:1,upserted:d.upserted});
+            return inspect(update);
+          })
+          .then(function(d) {
+            d = d[0];
+            assert.equal(d.nInserted,0);
+            assert.equal(d.nUpserted,0);
+            assert.equal(d.nMatched,0);
           });
-       });
+      });
     });
 
-    it('results are saved',function() {
-      return mongo.getCollection('upsert')
-        .then(function(collection) {
-          return collection.find({},{_id:false}).toArrayAsync();
-        })
-        .then(function(d) {
-          assert.deepEqual(d,data.data);
-        });
+    describe('with pushresults == false',function() {
+      it('pushes nothing downstream',function() {
+        return mongo.getCollection('update-empty')
+          .then(function(collection) {
+            var update = etl.mongo.update(collection,['name']);
+
+            data.stream()
+              .pipe(update);
+
+            return inspect(update);
+          })
+          .then(function(d) {
+            assert.deepEqual(d,[]);
+          });
+      });
+    });
+
+    describe('on a populated collection',function() {
+      it('should update matches',function() {
+        return mongo.getCollection('update-populated',true)
+          .then(function(collection) {
+            return collection.insertAsync(data.copy())
+              .then(function() {
+                var update = etl.mongo.update(collection,['name'],{pushResult:true});
+
+                data.stream()
+                  .pipe(etl.map(function(d) {
+                    if (d.name == 'Nathaniel Olson')
+                      d.name = 'Not Found';
+                    d.newfield='newfield';
+                    return d;
+                  }))
+                  .pipe(etl.collect(100))
+                  .pipe(update);
+
+                return inspect(update);
+              });
+          })
+          .then(function(d) {
+            d = d[0];
+            if (d.nModified === null)
+              console.log('WARNING - Mongo 2.6 or higher needed for nModfied');
+            else
+              assert.equal(d.nModified,2);
+            assert.equal(d.nInserted,0);
+          });
+      });
+
+      it('results are saved',function() {
+        return mongo.getCollection('update-populated',true)
+          .then(function(collection) {
+            return collection.find({},{_id:false}).toArrayAsync();
+          })
+          .then(function(d) {
+            var expected = data.copy().map(function(d,i) {
+              if (i) d.newfield = 'newfield';
+              return d;
+            });
+
+            assert.deepEqual(d,expected);            
+          });
+      });
+    });
+
+    describe('using upsert',function() {
+      it('should populate',function() {
+        return mongo.getCollection('upsert')
+          .then(function(collection) {
+            var upsert = etl.mongo.update(collection,['name'],{pushResult:true,upsert:true});
+
+            data.stream()
+              .pipe(etl.collect(100))
+              .pipe(upsert);
+
+            return inspect(upsert);
+          })
+          .then(function(d) {
+            d = d[0];
+            assert.equal(d.nUpserted,3);
+            assert.equal(d.nMatched,0);
+         });
+      });
+
+      it('results are saved',function() {
+        return mongo.getCollection('upsert')
+          .then(function(collection) {
+            return collection.find({},{_id:false}).toArrayAsync();
+          })
+          .then(function(d) {
+            assert.deepEqual(d,data.data);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
Switch update/upsert to use the bulk framework in mongo.
This allows `etl.collect(n)` to be placed above the `mongo.update`