### PR TITLE
Pass body in pushResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ etl.file('test.csv')
 ### `etl.elastic.bulk(action,client,index,type,[options])`
 Transmit incoming packets to elasticsearch, setting the appropriate meta-data depending on the default action. Each incoming packet can be an array of documents (or a single document).  Each document should contain a unique `_id`.   To bulk documents together use `etl.collect(num)` above the elastic adapter.
 
-The results are not pushed downstream unless `pushResults` is defined in the options.  Maximum number of concurrent connections can be defined as option `concurrency`.
+The results are not pushed downstream unless `pushResults` is defined in the options. The body of the incoming data is included in the results, allowing for easy resubmission upon version conflicts.  Maximum number of concurrent connections can be defined as option `concurrency`.
 
 Available actions are also provided as separate api commands:
 
@@ -241,5 +241,5 @@ etl.file('test.csv')
   .pipe(console.log);
 ```
 
-### `etl.stream(data)`
+### `etl.toStream(data)`
 A helper function that returns a stream that is initialized by writing every element of the supplied data (if array) before being ended.  This allows for an easy transition from a known set of elements to a flowing stream with concurrency control.

--- a/lib/elasticsearch/bulk.js
+++ b/lib/elasticsearch/bulk.js
@@ -65,8 +65,13 @@ Bulk.prototype._fn = function(d) {
       type : self.type
     },cb);
   })
-  .then(function(d) {
-    return self.options.pushResult && d;
+  .then(function(e) {
+    if (!self.options.pushResult)
+      return;
+    e.items.forEach(function(e,i) {
+      e.body = d[i];
+    });
+    return e;
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",

--- a/test/elastic-test.js
+++ b/test/elastic-test.js
@@ -35,10 +35,10 @@ describe('elastic bulk insert',function() {
       }))
       .pipe(etl.collect(100))
       .pipe(upsert)
-      .on('error',console.log)
       .promise()
       .then(function(d) {
         assert.equal(d[0].items.length,3);
+        assert.deepEqual(d[0].items[0].body,data.data[0]);
       });
   });
 


### PR DESCRIPTION
Include the incoming data in the output (allows resubmission upon version conflicts etc)