### PR TITLE
Improve bulk

### DIFF
--- a/lib/elasticsearch/bulk.js
+++ b/lib/elasticsearch/bulk.js
@@ -22,15 +22,27 @@ function Bulk(action,client,index,type,options) {
 
 util.inherits(Bulk,Streamz);
 
-Bulk.prototype.getMeta = function(id) {
-  var obj = {},
+Bulk.prototype.getMeta = function(d) {
+  var res = {},
       self=this,
       action = self.action == 'upsert' ? 'update' : self.action;
 
-  obj[action] = {
-    _id : id
+  var obj = res[action] = {
+    _id : d._id,
   };
-  return obj;
+  delete d._id;
+
+  if (!this.index) {
+    obj._index = d._index;
+    delete d._index;
+  }
+
+  if (!this.type) {
+    obj._type = d._type;
+    delete d._type;
+  }
+
+  return res;
 };
 
 Bulk.prototype._fn = function(d) {
@@ -46,8 +58,9 @@ Bulk.prototype._fn = function(d) {
       return p;
     }
 
-    p.push(self.getMeta(d._id));
-    delete d._id;
+    p.push(self.getMeta(d));
+    
+    d = d._source || d;
 
     if (self.action == 'index')
       p.push(d);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",


### PR DESCRIPTION
Use `_index` and `_type` from the document if not supplied in the constructor.
Use `_source` as the document body (if available) otherwise the document itself
This allows a direct pipe from `etl.elastic.scroll` to `etl.elastic.index`