### PR TITLE
Amend: toStream to allow `fn` or `Promise`

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ This function sends a numerical value representing progress up to the master (fo
 
 <a name="tostream" href="#tostream">#</a> etl.<b>toStream</b>(<i>data</i>)
 
-A helper function that returns a stream that is initialized by writing every element of the supplied data (if array) before being ended.  This allows for an easy transition from a known set of elements to a flowing stream with concurrency control.
+A helper function that returns a stream that is initialized by writing every element of the supplied data (if array) before being ended.  This allows for an easy transition from a known set of elements to a flowing stream with concurrency control.  The input `data` can also be supplied as a promise or a function and the resulting values will be piped to the returned stream.
 
 <a name="file" href="#file">#</a> etl.<b>file</b>(<i>data</i> [,<i>options</i>])
 

--- a/lib/tostream.js
+++ b/lib/tostream.js
@@ -1,10 +1,19 @@
 var Streamz = require('streamz');
+var Promise = require('bluebird');
 
 function toStream(data) {
   var stream = Streamz();
-  if (data !== undefined)
-    [].concat(data).forEach(stream.write.bind(stream));
-  stream.end();
+
+  if (typeof data == 'function')
+    data = Promise.try(data.bind(stream));
+
+  Promise.resolve(data)
+    .then(function(d) {
+      if (d !== undefined)
+        [].concat(d).forEach(stream.write.bind(stream));
+      stream.end();
+    });
+
   return stream;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",

--- a/test/tostream-test.js
+++ b/test/tostream-test.js
@@ -1,25 +1,76 @@
 var etl = require('../index'),
     assert = require('assert');
 
-
 describe('toStream',function() {
-  it('starts a stream using supplied data',function() {
-    return etl.toStream([1,2,[3,4]])
-      .pipe(etl.map(function(d) {
-        return [d];
-      }))
-      .promise()
-      .then(function(d) {
-        assert.deepEqual(d,[[1],[2],[[3,4]]]);
-      });
+  describe('static data',function() {
+    it('streams supplied data',function() {
+      return etl.toStream([1,2,[3,4]])
+        .pipe(etl.map(function(d) {
+          return [d];
+        }))
+        .promise()
+        .then(function(d) {
+          assert.deepEqual(d,[[1],[2],[[3,4]]]);
+        });
+    });
+
+    it('no data returns empty stream',function() {
+      return etl.toStream()
+        .promise()
+        .then(function(d) {
+          assert.deepEqual(d,[]);
+        });
+    });
   });
 
-  it('with no data is an empty stream',function() {
-    return etl.toStream()
+  describe('function input',function() {
+    it('streams the function results',function() {
+      return etl.toStream(function() {
+        return([1,2,[3,4]]);
+      })
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,[1,2,[3,4]]);
+      });
+    });
+
+    it('streams `this.push` and function results',function() {
+      return etl.toStream(function() {
+        this.push(1);
+        this.push(2);
+        return [[3,4]]
+      })
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,[1,2,[3,4]]);
+      });
+    });
+
+    it('no data returns empty stream',function() {
+      return etl.toStream(function() {
+      })
       .promise()
       .then(function(d) {
         assert.deepEqual(d,[]);
       });
+    });
   });
-    
+
+  describe('promise input',function() {
+    it('streams the resolved values',function() {
+      return etl.toStream(Promise.resolve([1,2,[3,4]]))
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,[1,2,[3,4]]);
+      });
+    });
+
+    it('no data returns empty stream',function() {
+      return etl.toStream(Promise.resolve())
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,[]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
The resolved or resulting values will be piped to the returned stream