### PR TITLE
Add: keepOpen(timeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,3 +378,7 @@ etl.toStream([1,2,3,4,5])
     console.log('error',e);
   })
 ```
+
+<a name="keepopen" href="#keepopen">#</a> etl.<b>keepOpen</b>(<i>[timeout]</i>)
+
+`etl.keepOpen([timeout])` is a passthrough component that stays open after receiving an `end` only to finally close down when no data has passed through for a period of `[timeout]`.  This can be useful for any pipelines where data from lower part of the pipeline is pushed back higher for reprocessing (for example when encountering version conflicts of database documents) - as it will avoid `write after end` error.   The default timeout is 1000ms

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,5 +20,6 @@ module.exports = {
   toStream : require('./tostream'),
   toFile : require('./toFile'),
   map : streamz,
+  keepOpen: require('./keepOpen'),
   streamz : streamz
 };

--- a/lib/keepOpen.js
+++ b/lib/keepOpen.js
@@ -1,0 +1,31 @@
+var Streamz = require('streamz'),
+    util = require('util');
+
+function KeepOpen(timeout) {
+  if (!(this instanceof Streamz))
+    return new KeepOpen(timeout);
+  Streamz.call(this);
+  this.timeout = timeout || 1000;
+}
+
+util.inherits(KeepOpen,Streamz);
+
+KeepOpen.prototype._fn = function(d) {
+  this.last = new Date();
+  return Streamz.prototype._fn.apply(this,arguments);
+};
+
+KeepOpen.prototype.end = function(d) {
+  var self = this;
+  if (d !== null && d !== undefined)
+    this.write(d);
+
+  var timer = setInterval(function() {
+    if (new Date() - self.last > self.timeout) {
+      clearInterval(timer);
+      Streamz.prototype.end.call(self);
+    }
+  },self.timeout);
+};
+
+module.exports = KeepOpen;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",

--- a/test/keepopen-test.js
+++ b/test/keepopen-test.js
@@ -1,0 +1,46 @@
+var etl = require('../index'),
+    assert = require('assert'),
+    Promise = require('bluebird');
+
+describe('keepOpen',function() {
+  it('stays open after end as long as data arrives before timeout',function() {
+    var p = etl.keepOpen(500);
+
+    return etl.toStream([1,999,[3,4]])
+      .pipe(p)
+      .pipe(etl.map(function(d) {
+        if (d === 999)
+          Promise.delay(200)
+           .then(p.write.bind(p,2));
+        else
+          return d;
+      }))
+      .promise()
+      .then(function(d) {
+        assert.deepEqual(d,[1,[3,4],2]);
+      });
+  });
+
+  it('errors `write after end` if data arrives after timeout',function() {
+    var p = etl.keepOpen(100);
+
+    return etl.toStream([1,undefined,[3,4]])
+      .pipe(p)
+      .pipe(etl.map(function(d) {
+        if (d === undefined)
+          return Promise.delay(1000)
+           .then(p.write.bind(p,2));
+          
+        else
+          return d;
+      }))
+      .promise()
+      .then(function() {
+        throw 'Should Error';
+      },function(e) {
+        assert(e.message === 'stream.push() after EOF' || e.message === 'write after end',e.message);
+      });
+  });
+
+  
+});


### PR DESCRIPTION
To help with packets that are kicked up the pipeline again for reprocessing.  This component stays open until timeout from last packet received.