### PR TITLE
Bump streamz

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.3.37",
+  "version": "0.4.0",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",
@@ -17,7 +17,7 @@
     "csv-parser": "~1.8.0",
     "duplexer2": "~0.1.4",
     "moment": "~2.12.0",
-    "streamz": "~1.6.2"
+    "streamz": "~1.7.0"
   },
   "devDependencies": {
     "mongodb": "~2.1.6",


### PR DESCRIPTION
Instead of monitoring finalize after end through _flush we pause ending the stream until all concurrent requests are done *and* writable buffer is zero.    Looking for zero-length writable buffer allows `write` to self within the transform even if the inbound pipe(s) have ended