### PR TITLE
Fix Postgres TABLE_NOT_FOUND error

### DIFF
--- a/lib/postgres/script.js
+++ b/lib/postgres/script.js
@@ -10,7 +10,7 @@ function Script(pool, schema, table, options) {
   this.schema = schema;
   this.table = table;
   this.columns = this.getColumns();
-  this.pkeys = this.getPrimayKeys();
+  this.pkeys = this.getPrimaryKeys();
   this.prefix = this.options.prefix || 'INSERT INTO';
 }
 
@@ -29,13 +29,13 @@ Script.prototype.getColumns = function () {
     });
 };
 
-Script.prototype.getPrimayKeys = function () {
-  const sql = 'SELECT a.attname'
-    + ' FROM   pg_index i'
-    + ' JOIN   pg_attribute a ON a.attrelid = i.indrelid'
-    + ' AND a.attnum = ANY(i.indkey)'
-    + ` WHERE  i.indrelid = '${this.table}'::regclass`
-    + ' AND    i.indisprimary;';
+Script.prototype.getPrimaryKeys = function () {
+  const sql = 'SELECT a.attname' +
+    ' FROM   pg_index i' +
+    ' JOIN   pg_attribute a ON a.attrelid = i.indrelid' +
+    ' AND a.attnum = ANY(i.indkey)' +
+    ` WHERE  i.indrelid = '${this.schema}.${this.table}'::regclass` +
+    ' AND    i.indisprimary;';
 
   return this.query(sql)
     .then(d => d.rows.map(d => d.attname));
@@ -59,19 +59,19 @@ Script.prototype._fn = function (record) {
       return;
 
     if (!this.buffer)
-      this.buffer = `${this.prefix} ${this.table} ( ${columns.join(',')} ) VALUES `;
+      this.buffer = `${this.prefix} ${this.schema}.${this.table} ( ${columns.map(quoteString).join(',')} ) VALUES `;
     this.buffer += '(' + columns.map(key => {
-      const value = d[key];
-      if (typeof value === 'undefined')
-        return 'DEFAULT';
-      else if (value === null)
-        return 'null';
-      else if (typeof value === 'object')
-        return escapeLiteral(JSON.stringify(value));
-      else
-        return escapeLiteral(value);
-    })
-    .join(',') + ')';
+        const value = d[key];
+        if (typeof value === 'undefined')
+          return 'DEFAULT';
+        else if (value === null)
+          return 'null';
+        else if (typeof value === 'object')
+          return escapeLiteral(JSON.stringify(value));
+        else
+          return escapeLiteral(value);
+      })
+      .join(',') + ')';
 
 
     let tmp_arr = [];
@@ -80,7 +80,7 @@ Script.prototype._fn = function (record) {
       if (typeof value === 'undefined')
         continue;
 
-      let sql = columns[i] + ' = ';
+      let sql = `"${columns[i]}" =`;
       if (value === null)
         sql += 'null';
       else if (typeof value === 'object')
@@ -91,8 +91,8 @@ Script.prototype._fn = function (record) {
       tmp_arr.push(sql);
     }
     if (tmp_arr.length && pkeys.length)
-      this.buffer += ` ON CONFLICT (${pkeys.join(', ')} ) DO UPDATE SET ${tmp_arr.join(', ')}`;
-    this.buffer +=  ';';
+      this.buffer += ` ON CONFLICT (${pkeys.map(quoteString).join(', ')}) DO UPDATE SET ${tmp_arr.join(', ')}`;
+    this.buffer += ';';
     this._push();
   });
 };
@@ -128,6 +128,10 @@ function escapeLiteral(str) {
     escaped = ' E' + escaped;
 
   return escaped;
+}
+
+function quoteString(str) {
+  return `"${str}"`;
 }
 
 module.exports = Script;

--- a/lib/postgres/script.js
+++ b/lib/postgres/script.js
@@ -1,6 +1,8 @@
 const Postgres = require('./postgres');
 const util = require('util');
 
+const quoteString = (str) => `"${str}"`;
+
 function Script(pool, schema, table, options) {
   if (!(this instanceof Script))
     return new Script(pool, schema, table, options);
@@ -128,10 +130,6 @@ function escapeLiteral(str) {
     escaped = ' E' + escaped;
 
   return escaped;
-}
-
-function quoteString(str) {
-  return `"${str}"`;
 }
 
 module.exports = Script;

--- a/lib/postgres/script.js
+++ b/lib/postgres/script.js
@@ -18,7 +18,7 @@ util.inherits(Script, Postgres);
 
 Script.prototype.getColumns = function () {
   const sql = 'SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE ' +
-    `TABLE_CATALOG='${this.schema}' AND TABLE_NAME='${this.table}';`;
+    `TABLE_SCHEMA='${this.schema}' AND TABLE_NAME='${this.table}';`;
 
   return this.query(sql)
     .then(d => {
@@ -57,8 +57,8 @@ Script.prototype._fn = function (record) {
 
     if (typeof d === 'undefined')
       return;
-    
-    if (!this.buffer) 
+
+    if (!this.buffer)
       this.buffer = `${this.prefix} ${this.table} ( ${columns.join(',')} ) VALUES `;
     this.buffer += '(' + columns.map(key => {
       const value = d[key];

--- a/test/postgres-test.js
+++ b/test/postgres-test.js
@@ -13,22 +13,22 @@ const pool = new pg.Pool({
 
 const p = etl.postgres.execute(pool);
 
-const before = p.query('CREATE SCHEMA circle_test')
+const before = p.query('CREATE SCHEMA circle_test_schema')
   .catch(Object)
-  .then(() => p.query('DROP TABLE IF EXISTS test;'))  
+  .then(() => p.query('DROP TABLE IF EXISTS circle_test_schema.test;'))
   .then(()  => p.query(
-    'CREATE TABLE test ('+
+    'CREATE TABLE circle_test_schema.test ('+
     'name varchar(45),'+
     'age integer,'+
     'dt date '+
     ')'
   ));
- 
+
 t.test('postgres', async t => {
   await before;
   t.test('inserts', async t => {
     const d = await data.stream()
-      .pipe(etl.postgres.upsert(pool,'circle_test','test',{pushResult:true}))
+      .pipe(etl.postgres.upsert(pool,'circle_test_schema','test',{pushResult:true}))
       .promise();
 
     t.same(d.length,3,'returns correct length');

--- a/test/postgres-test.js
+++ b/test/postgres-test.js
@@ -42,12 +42,12 @@ t.test('postgres', async t => {
     }))
     .sort((a,b) => a.age - b.age);
 
-    const d = await p.query('SELECT * from test order by age');
+    const d = await p.query('SELECT * from circle_test_schema.test order by age');
     t.same(d.rows,expected,'records verified');
   });
 
   t.test('streaming', async t => {
-    const d = await p.stream(new QueryStream('select * from test'))
+    const d = await p.stream(new QueryStream('select * from circle_test_schema.test'))
       .pipe(etl.map())
       .promise();
 


### PR DESCRIPTION
Created a new table in postgres in a new schema. However, at the time of `upsert` noticed that it is throwing a `TABLE_NOT_FOUND` error. Inspecting closely the query used for column discovery, filters on `TABLE_CATALOG` instead of `TABLE_SCHEMA`.

Also noticed the column names are not quoted, causing the following error:

`column "my_column_name" of relation "my_table_name" does not exist`

Fixed this along with the tests and opening a PR

### Test output:
```
> node test/postgres-test.js
TAP version 13
# Subtest: postgres
    # Subtest: inserts
        ok 1 - returns correct length
        1..1
    ok 1 - inserts # time=26.263ms

    # Subtest: and records are verified
        ok 1 - records verified
        1..1
    ok 2 - and records are verified # time=3.751ms

    # Subtest: streaming
        ok 1 - work
        1..1
    ok 3 - streaming # time=3.629ms

    1..3
ok 1 - postgres # time=57.761ms

1..1
# time=64.672ms
```
@willfarrell Thanks for adding support for Postgres. Kindly review