### PR TITLE
Fix #69 Migrating to class syntax

### DIFF
--- a/lib/mysql/script.js
+++ b/lib/mysql/script.js
@@ -8,7 +8,7 @@ function Script(pool,schema,table,options) {
   Mysql.call(this,pool,options);
 
   this.schema = schema;
-  this.table = table;  
+  this.table = table;
   this.columns = this.getColumns();
   this.prefix = this.options.prefix || 'REPLACE INTO ';
   this.maxBuffer = this.options.maxBuffer || 1024 * 1024;
@@ -58,7 +58,7 @@ Script.prototype._fn = function(d) {
 };
 
 Script.prototype._flush = function(cb) {
-  this._push();  
+  this._push();
   setImmediate(() => Mysql.prototype._flush(cb));
 };
 

--- a/lib/postgres/execute.js
+++ b/lib/postgres/execute.js
@@ -1,22 +1,16 @@
 const Postgres = require('./postgres');
-const util = require('util');
 
-function Execute(pool,options) {
-  if (!(this instanceof Execute))
-    return new Execute(pool,options);
+class Execute extends Postgres {
+  constructor(pool, options = {}) {
+    super(pool, options);
+  }
 
-  options = options || {};
-  Postgres.call(this,pool,options);
-
+  _fn(d, cb) {
+    // TODO make transaction or use {maxBuffer:1} in options
+    // console.log(d);
+    return this.query(d, cb)
+      .then(d => this.options.pushResult && d || undefined);
+  }
 }
 
-util.inherits(Execute,Postgres);
-
-Execute.prototype._fn = function(d,cb) {
-  // TODO make transaction or use {maxBuffer:1} in options
-  //console.log(d);
-  return this.query(d,cb)
-    .then(d => this.options.pushResult && d || undefined);
-};
-
-module.exports = Execute;
+module.exports = (...params) => new Execute(...params);

--- a/lib/postgres/postgres.js
+++ b/lib/postgres/postgres.js
@@ -1,58 +1,54 @@
 const Streamz = require('streamz');
-const util = require('util');
 const Promise = require('bluebird');
 
-function Postgres(pool,options) {
-  if (!(this instanceof Postgres))
-    return new Postgres(pool);
+class Postgres extends Streamz {
+  constructor(pool, options = {}) {
+    super(pool, options);
 
-  if (!pool)
-    throw 'POOL_MISSING';
+    if (!pool)
+      throw 'POOL_MISSING';
 
-  Streamz.call(this,options);
-  this.pool = pool;
-  this.options = options || {};
-}
-
-util.inherits(Postgres,Streamz);
-
-Postgres.prototype.getConnection = function() {
-  // Needs from refactor
-  return Promise.fromNode(this.pool.connect.bind(this.pool))
-    .disposer(connection => connection.release());
-};
-
-Postgres.prototype.query = function(query,cb) {
-  return Promise.using(this.getConnection(), connection => {
-    // Trigger callback when we get a connection, not when we (later) get results
-    // allowing overall concurrency to be controlled by the Postgres pool
-    if (typeof cb === 'function') cb();
-    return Promise.fromNode(callback => connection.query(query,callback));
-  });
-};
-
-Postgres.prototype.stream = function(query,cb) {
-  const passThrough = Streamz();
-
-  if (!query || query.state !== 'initialized') {
-    passThrough.emit('error',new Error('Query should be QueryStream'));
-    return passThrough;
+    this.pool = pool;
+    this.options = options;
   }
 
-  Promise.using(this.getConnection(),connection => {
-    // Trigger callback when we get a connection, not when we (later) get results
-    // allowing overall concurrency to be controlled by the Postgres pool
-    if (typeof cb === 'function') cb();
-    return new Promise((resolve,reject) => {
-      connection.query(query)
-        .on('end',resolve)
-        .on('error',reject)
-        .pipe(passThrough);
-    });
-  })
-  .catch(e => passThrough.emit('error',e));
+  getConnection() {
+    return Promise.fromNode(this.pool.connect.bind(this.pool))
+      .disposer(connection => connection.release());
+  }
 
-  return passThrough; 
-};
+  query(query, cb) {
+    return Promise.using(this.getConnection(), connection => {
+      // Trigger callback when we get a connection, not when we (later) get results
+      // allowing overall concurrency to be controlled by the Postgres pool
+      if (typeof cb === 'function') cb();
+      return Promise.fromNode(callback => connection.query(query, callback));
+    });
+  }
+
+  stream(query, cb) {
+    const passThrough = Streamz();
+
+    if (!query || query.state !== 'initialized') {
+      passThrough.emit('error', new Error('Query should be QueryStream'));
+      return passThrough;
+    }
+
+    Promise.using(this.getConnection(), connection => {
+      // Trigger callback when we get a connection, not when we (later) get results
+      // allowing overall concurrency to be controlled by the Postgres pool
+      if (typeof cb === 'function') cb();
+      return new Promise((resolve, reject) => {
+        connection.query(query)
+          .on('end', resolve)
+          .on('error', reject)
+          .pipe(passThrough);
+      });
+    })
+    .catch(e => passThrough.emit('error', e));
+
+    return passThrough;
+  }
+}
 
 module.exports = Postgres;

--- a/lib/postgres/script.js
+++ b/lib/postgres/script.js
@@ -1,68 +1,62 @@
 const Postgres = require('./postgres');
-const util = require('util');
 
 const quoteString = (str) => `"${str}"`;
 
-function Script(pool, schema, table, options) {
-  if (!(this instanceof Script))
-    return new Script(pool, schema, table, options);
+class Script extends Postgres {
+  constructor(pool, schema, table, options) {
+    super(pool, options);
 
-  Postgres.call(this, pool, options);
+    this.schema = schema;
+    this.table = table;
+    this.columns = this.getColumns();
+    this.pkeys = this.getPrimaryKeys();
+    this.prefix = this.options.prefix || 'INSERT INTO';
+  }
 
-  this.schema = schema;
-  this.table = table;
-  this.columns = this.getColumns();
-  this.pkeys = this.getPrimaryKeys();
-  this.prefix = this.options.prefix || 'INSERT INTO';
-}
+  getColumns() {
+    const sql = 'SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE ' +
+      `TABLE_SCHEMA='${this.schema}' AND TABLE_NAME='${this.table}';`;
 
-util.inherits(Script, Postgres);
+    return this.query(sql)
+      .then(d => {
+        d = d.rows;
+        if (!d.length)
+          throw 'TABLE_NOT_FOUND';
+        return d.map(d => d.column_name);
+      });
+  }
 
-Script.prototype.getColumns = function () {
-  const sql = 'SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE ' +
-    `TABLE_SCHEMA='${this.schema}' AND TABLE_NAME='${this.table}';`;
+  getPrimaryKeys() {
+    const sql = 'SELECT a.attname' +
+      ' FROM   pg_index i' +
+      ' JOIN   pg_attribute a ON a.attrelid = i.indrelid' +
+      ' AND a.attnum = ANY(i.indkey)' +
+      ` WHERE  i.indrelid = '${this.schema}.${this.table}'::regclass` +
+      ' AND    i.indisprimary;';
 
-  return this.query(sql)
-    .then(d => {
-      d = d.rows;
-      if (!d.length)
-        throw 'TABLE_NOT_FOUND';
-      return d.map(d => d.column_name);
-    });
-};
+    return this.query(sql)
+      .then(d => d.rows.map(d => d.attname));
+  }
 
-Script.prototype.getPrimaryKeys = function () {
-  const sql = 'SELECT a.attname' +
-    ' FROM   pg_index i' +
-    ' JOIN   pg_attribute a ON a.attrelid = i.indrelid' +
-    ' AND a.attnum = ANY(i.indkey)' +
-    ` WHERE  i.indrelid = '${this.schema}.${this.table}'::regclass` +
-    ' AND    i.indisprimary;';
+  _push() {
+    if (this.buffer) {
+      this.push(this.buffer);
+    }
+    this.buffer = undefined;
+  }
 
-  return this.query(sql)
-    .then(d => d.rows.map(d => d.attname));
-};
+  _fn(record) {
+    return Promise.all([this.columns, this.pkeys]).then(data => {
+      const columns = data[0];
+      const pkeys = data[1];
+      const d = (Array.isArray(record)) ? record[0] : record;
 
-Script.prototype.buffer = undefined;
+      if (typeof d === 'undefined')
+        return;
 
-Script.prototype._push = function () {
-  if (this.buffer)
-    this.push(this.buffer);
-  this.buffer = undefined;
-};
-
-Script.prototype._fn = function (record) {
-  return Promise.all([this.columns, this.pkeys]).then(data => {
-    const columns = data[0];
-    const pkeys = data[1];
-    const d = (Array.isArray(record)) ? record[0] : record;
-
-    if (typeof d === 'undefined')
-      return;
-
-    if (!this.buffer)
-      this.buffer = `${this.prefix} ${this.schema}.${this.table} ( ${columns.map(quoteString).join(',')} ) VALUES `;
-    this.buffer += '(' + columns.map(key => {
+      if (!this.buffer)
+        this.buffer = `${this.prefix} ${this.schema}.${this.table} ( ${columns.map(quoteString).join(',')} ) VALUES `;
+      this.buffer += '(' + columns.map(key => {
         const value = d[key];
         if (typeof value === 'undefined')
           return 'DEFAULT';
@@ -73,36 +67,37 @@ Script.prototype._fn = function (record) {
         else
           return escapeLiteral(value);
       })
-      .join(',') + ')';
+        .join(',') + ')';
 
 
-    let tmp_arr = [];
-    for (let i = 0, l = columns.length; i < l; i++) {
-      const value = d[columns[i]];
-      if (typeof value === 'undefined')
-        continue;
+      let tmp_arr = [];
+      for (let i = 0, l = columns.length; i < l; i++) {
+        const value = d[columns[i]];
+        if (typeof value === 'undefined')
+          continue;
 
-      let sql = `"${columns[i]}" =`;
-      if (value === null)
-        sql += 'null';
-      else if (typeof value === 'object')
-        sql += escapeLiteral(JSON.stringify(value));
-      else
-        sql += escapeLiteral(value);
+        let sql = `"${columns[i]}" =`;
+        if (value === null)
+          sql += 'null';
+        else if (typeof value === 'object')
+          sql += escapeLiteral(JSON.stringify(value));
+        else
+          sql += escapeLiteral(value);
 
-      tmp_arr.push(sql);
-    }
-    if (tmp_arr.length && pkeys.length)
-      this.buffer += ` ON CONFLICT (${pkeys.map(quoteString).join(', ')}) DO UPDATE SET ${tmp_arr.join(', ')}`;
-    this.buffer += ';';
+        tmp_arr.push(sql);
+      }
+      if (tmp_arr.length && pkeys.length)
+        this.buffer += ` ON CONFLICT (${pkeys.map(quoteString).join(', ')}) DO UPDATE SET ${tmp_arr.join(', ')}`;
+      this.buffer += ';';
+      this._push();
+    });
+  }
+
+  _flush(cb) {
     this._push();
-  });
-};
-
-Script.prototype._flush = function (cb) {
-  this._push();
-  setImmediate(() => Postgres.prototype._flush(cb));
-};
+    setImmediate(() => Postgres.prototype._flush(cb));
+  }
+}
 
 // https://github.com/brianc/node-postgres/blob/83a946f61cb9e74c7f499e44d03a268c399bd623/lib/client.js
 function escapeLiteral(str) {
@@ -132,4 +127,4 @@ function escapeLiteral(str) {
   return escaped;
 }
 
-module.exports = Script;
+module.exports = (...params) => new Script(...params);

--- a/lib/postgres/upsert.js
+++ b/lib/postgres/upsert.js
@@ -4,7 +4,7 @@ const execute = require('./execute');
 
 module.exports = function upsert(pool,schema,table,options) {
   return chain(inStream => inStream
-    .pipe(script(pool,schema,table,options))
-    .pipe(execute(pool,options))
+    .pipe(script(pool, schema, table, options))
+    .pipe(execute(pool, options))
   );
 };


### PR DESCRIPTION
@willfarrell @ZJONSSON 

No other code changes other than just converting postgres module to `class`syntax as discussed in #69 .

Made sure backward compatibility by exporting instance of class in `lib/postgres/execute.js` and `lib/postgres/script.js` and running test.

## Test output
```
$ node test/postgres-test.js
TAP version 13
# Subtest: postgres
    # Subtest: inserts
        ok 1 - returns correct length
        1..1
    ok 1 - inserts # time=27.193ms

    # Subtest: and records are verified
        ok 1 - records verified
        1..1
    ok 2 - and records are verified # time=3.172ms

    # Subtest: streaming
        ok 1 - work
        1..1
    ok 3 - streaming # time=4.508ms

    1..3
ok 1 - postgres # time=57.515ms

1..1
# time=63.577ms
```