### PR TITLE
Fix split when stream is empty

### DIFF
--- a/lib/split.js
+++ b/lib/split.js
@@ -16,7 +16,7 @@ Split.prototype.buffer = '';
 Split.prototype.__line = 0;
 
 Split.prototype._push = function() {
-  if (this.buffer.text.trim().length)
+  if (this.buffer && this.buffer.text.trim().length)
     this.push(this.buffer);
   delete this.buffer;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",

--- a/test/split-test.js
+++ b/test/split-test.js
@@ -52,3 +52,11 @@ t.test('split(\'a\')', async t => {
   const d = await split.pipe(etl.expand()).promise();
   t.same(d,expected,'splits on a');
 });
+
+t.test('etl.split empty', async t => {
+  const p = etl.map();
+  p.end();
+
+  const data = await p.pipe(etl.split()).promise();
+  t.same(data,[]);
+});


### PR DESCRIPTION
In which case `this.buffer` has not been defined yet