### PR TITLE
Docker node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.docker_node_modules/
 /node_modules/
 /.nyc_output/
 /coverage/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+
+    {
+      "type": "node",
+      "request": "attach",
+      "preLaunchTask": "Inspect Current File (Docker)",
+      "name": "Debug current file (docker)",
+      "localRoot": "${workspaceRoot}",
+      "remoteRoot": "/usr/src/app",
+     // "address": "172.19.0.100",
+      "port": 9229,
+  },
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Inspect Current File (Docker)",
+      "type": "shell",
+      "command": "bash docker exec -it etl_runner_1 pkill -f ':9229';(docker exec  etl_runner_1 node --inspect-brk=173.23.0.100:9229 /usr/src/app/${relativeFile} &);sleep 1",
+      "group": "test",
+    },
+    {
+      "label": "Tap Current File (Docker)",
+      "type": "shell",
+      "command": "docker exec -it etl_runner_1 tap -Rspec /usr/src/app/${relativeFile}",
+      "group": "test",
+    },
+    {
+      "label": "All Unit tests (Docker)",
+      "type": "shell",
+      "command": "npm test",
+      "group": "test",
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ RUN apt-get update
 RUN wget http://ftp.us.debian.org/debian/pool/main/w/wait-for-it/wait-for-it_0.0~git20160501-1_all.deb
 RUN dpkg -i ./wait-for-it_0.0~git20160501-1_all.deb
 RUN apt-get install -f
+RUN npm install -g tap

--- a/README.md
+++ b/README.md
@@ -499,8 +499,8 @@ etl.toStream([1,2,3,4,5])
 
 ## Testing
 
-Testing environment is provided using docker-compose.  Start all services as follows:
-```
-docker-compose -p etl up
-```
-and then run `npm test` or go directly into the container (`docker exec -it etl_runner_1 bash`) and run individual tests manually 
+Testing environment is provided using docker-compose.  
+
+`npm test` starts docker-compose (if not already running) and executes the test suite.
+
+You can run individual tests from the docker directly.  To enter the docker type `npm run docker`

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ jobs:
     steps:
       - checkout
       - run: docker-compose -p etl up -d
-      - run: npm install
       - run: npm test
       - store_artifacts:
           path: coverage/lcov-report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,13 +25,18 @@ services:
      - .:/usr/src/app
      - ./.docker_node_modules:/usr/src/app/node_modules:Z
     command: sh -c 'tail -f /dev/null'
+    ports:
+      - "9229:9229"
+    expose:
+      - 9229
+    networks:
+      etl-network:
+        ipv4_address: 173.23.0.100
 
   mongodb:
     image: 'mongo:3.2.17'
-    ports:
-      - "27017:27017"
-    expose:
-      - 27017
+    networks:
+      - etl-network
 
   mysql:
     image: mysql
@@ -39,13 +44,25 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
+    networks:
+      - etl-network
 
   postgres:
     image: postgres
     restart: always
     environment:
       POSTGRES_PASSWORD: example
+    networks:
+      - etl-network
 
   elasticsearch:
     image: elasticsearch:6.4.1
     environment: ['http.host=0.0.0.0', 'transport.host=127.0.0.1']
+    networks:
+      - etl-network
+
+networks:
+  etl-network:
+    ipam:
+     config:
+       - subnet: 173.23.0.0/16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,15 @@ services:
     working_dir: /usr/src/app
     volumes:
      - .:/usr/src/app
+     - ./.docker_node_modules:/usr/src/app/node_modules:Z
     command: sh -c 'tail -f /dev/null'
 
   mongodb:
     image: 'mongo:3.2.17'
+    ports:
+      - "27017:27017"
+    expose:
+      - 27017
 
   mysql:
     image: mysql

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "http://github.com/ZJONSSON/node-etl"
   },
   "scripts": {
-    "test": "docker exec -it etl_runner_1 bash ./test.sh"
+    "test": "docker-compose -p etl up -d --no-recreate;docker exec -it etl_runner_1 bash ./test.sh",
+    "docker": "docker-compose -p etl up -d --no-recreate;docker exec -it etl_runner_1 bash"
   },
   "license": "MIT",
   "dependencies": {

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
+npm install
 wait-for-it elasticsearch:9200
 wait-for-it mongodb:27017
 wait-for-it mysql:3306


### PR DESCRIPTION
* Mount `.docker_node_modules` as `node_modules` inside the docker.  This allows us to eliminate conflicts between the node install inside the docker vs. a local npm install.
* Add vscode debug scripts: debug current file from docker or local and run full unit tests 