### PR TITLE
Quote column names for MySQL

### DIFF
--- a/lib/mysql/script.js
+++ b/lib/mysql/script.js
@@ -39,7 +39,7 @@ Script.prototype._push = function() {
 Script.prototype._fn = function(d) {
   return this.columns.then(columns => {
     if (!this.buffer)
-      this.buffer = `${this.prefix} \`${this.schema}\`.\`${this.table}\` ( ${columns.join(',')} ) VALUES`;
+      this.buffer = `${this.prefix} \`${this.schema}\`.\`${this.table}\` (\`${columns.join('`,`')}\`) VALUES `;
     else
       this.buffer += ', ';
 


### PR DESCRIPTION
Ensure that column names are quoted, to allow for reserved keywords to be used as a column name