### PR TITLE
Backwards compatible implementation of new elastic client

### DIFF
--- a/lib/elasticsearch/bulk.js
+++ b/lib/elasticsearch/bulk.js
@@ -127,6 +127,8 @@ Bulk.prototype._fn = function(d) {
       if (!this.options.pushResult && !this.options.pushErrors)
         return;
 
+      if (e.body) e = e.body;
+
       // Insert a copy of the original body
       e.items.forEach((e,i) => e.body = itemsToProcess[i * 2 + 1]);
 

--- a/lib/elasticsearch/find.js
+++ b/lib/elasticsearch/find.js
@@ -20,10 +20,13 @@ Find.prototype.search = function(d) {
 
 Find.prototype._fn = function(query) {
   return this.search(query)
-    .then(d => d.hits.hits.forEach(d => {
-      d._search = query;
-      this.push(d);
-    }));
+    .then(d => {
+      if (d.body) d = d.body;
+      d.hits.hits.forEach(d => {
+        d._search = query;
+        this.push(d);
+      });
+    });
 };
 
 module.exports = Find;

--- a/lib/elasticsearch/scroll.js
+++ b/lib/elasticsearch/scroll.js
@@ -33,6 +33,7 @@ Scroll.prototype._read = function() {
     
   return this.search
     .then(d => {
+      if (d.body) d = d.body;
       this.search = undefined;
       this.scroll_id = this.scroll_id || d._scroll_id;
       

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "streamz": "~1.8.4"
   },
   "devDependencies": {
-    "elasticsearch": "~13.0.0",
+    "@elastic/elasticsearch": "~7.1.0",
     "mongodb": "~2.2.27",
     "mysql": "^2.17.1",
     "pg": "~6.2.3",

--- a/test/elastic-test.js
+++ b/test/elastic-test.js
@@ -1,11 +1,11 @@
 const etl = require('../index');
 const data = require('./data');
 const Promise = require('bluebird');
-const elasticsearch = require('elasticsearch');
+const elasticsearch = require('@elastic/elasticsearch');
 const t = require('tap');
 
 const client = new elasticsearch.Client({
-  host: 'elasticsearch:9200'
+  node: 'http://elasticsearch:9200'
 });
 
 function convertHits(d) {
@@ -52,7 +52,8 @@ t.test('elastic', {autoend:true}, async t => {
 
   t.test('retreive data with client.search()', async t => {
     await Promise.delay(2000); 
-    const d = await client.search({index:'test',type:'test'});
+    let d = await client.search({index:'test',type:'test'});
+    if (d.body) d = d.body;
     const values = convertHits(d.hits.hits);
     t.same(values,data.data,'data matches');
   });
@@ -61,8 +62,9 @@ t.test('elastic', {autoend:true}, async t => {
     const find = etl.elastic.find(client);
     find.end({index:'test','type':'test'});
 
-    const d = await find.promise();  
+    let d = await find.promise();  
     const values = convertHits(d);
+    if (d.body) d = d.body;
     t.same(values,data.data,'returns original data');
   });
 


### PR DESCRIPTION
The main breaking change is that the new clients returns the actual results under `.body`
Here we simply check for a `.body` and swap into results if exists