### PR TITLE
More flexible mongo.update

### DIFF
--- a/lib/mongo/update.js
+++ b/lib/mongo/update.js
@@ -43,7 +43,9 @@ Update.prototype._fn = function(d) {
         if (this.options.upsert)
           op = op.upsert();
 
-        op.updateOne({$set:d});
+        const payload = (d.$set || d.$addToSet) ? d : {$set: d};
+
+        op.updateOne(payload);
       });
 
       return bulk.execute(this.options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etl",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Collection of stream-based components that form an ETL pipeline",
   "main": "index.js",
   "author": "Ziggy Jonsson (http://github.com/zjonsson/)",


### PR DESCRIPTION
Allows defining $set and $addToSet  directly in the data objects passed to mongo.update