### PR TITLE
Do not retry a mapping_parser_exception

### DIFF
--- a/lib/elasticsearch/bulk.js
+++ b/lib/elasticsearch/bulk.js
@@ -136,7 +136,7 @@ Bulk.prototype._fn = function(d) {
         let itemsToRetry;
         e.items.forEach((item, index) => {
           const verb = item.update || item.index || item.create;
-          if (verb && verb.error) {
+          if (verb && verb.error && verb.error.type !== 'mapper_parsing_exception') {
             itemsToRetry = itemsToRetry || [];
             itemsToRetry.push(itemsToProcess[index * 2]);
             itemsToRetry.push(itemsToProcess[index * 2 + 1]);


### PR DESCRIPTION
The new retry mechanism works great when we need to actually retry.  However in cases where we get errors that can not be resolved by retrying we need to move on.   One important example is `mapping_parser_exception`