### PR TITLE
Mongo upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
         ipv4_address: 173.23.0.100
 
   mongodb:
-    image: 'mongo:3.2.17'
+    image: 'mongo:3.4-xenial'
     networks:
       - etl-network
 

--- a/lib/mongo/bulk.js
+++ b/lib/mongo/bulk.js
@@ -66,7 +66,7 @@ Update.prototype._fn = function(d,cb) {
         op.updateOne(d);
       });
 
-      bulk.execute(this.options,(err,d) => {
+      bulk.execute(this.options.writeConcern,(err,d) => {
         console.log('inserted', d.nInserted,'upserted', d.nUpserted, 'nMatched', d.nMatched, 'upserted', d.upserted,  err);
         cb(err,this.options.pushResult && d);
       });

--- a/lib/mongo/update.js
+++ b/lib/mongo/update.js
@@ -48,7 +48,7 @@ Update.prototype._fn = function(d) {
         op.updateOne(payload);
       });
 
-      return bulk.execute(this.options);
+      return bulk.execute(this.options.writeConcern);
     })
     .then(d => {
       if (this.options.pushResult)


### PR DESCRIPTION
Mongo now errors if we pass anything but `writeConcern` to the `bulk.execute`.
This is a quick fix