### PR TITLE
fix(postgres): double quote identifiers

### DIFF
--- a/lib/postgres/script.js
+++ b/lib/postgres/script.js
@@ -63,7 +63,7 @@ class Script extends Postgres {
         return;
 
       if (!this.buffer)
-        this.buffer = `${this.prefix} ${this.schema}.${this.table} ( ${columns.map(quoteString).join(',')} ) VALUES `;
+        this.buffer = `${this.prefix} "${this.schema}"."${this.table}" ( ${columns.map(quoteString).join(',')} ) VALUES `;
       else
         this.buffer += ', ';
 


### PR DESCRIPTION
This fixes an issue related to not being able to use any relation name that is not fully lowercase